### PR TITLE
workaround JDK-8262895 by disabling subtest

### DIFF
--- a/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointers.java
+++ b/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointers.java
@@ -125,9 +125,11 @@ public class CompressedClassPointers {
             "-XX:+VerifyBeforeGC", "-version");
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         if (testNarrowKlassBase()) {
-            output.shouldContain("Narrow klass base: 0x0000000000000000");
-            if (!Platform.isAArch64() && !Platform.isOSX()) {
-                output.shouldContain("Narrow klass shift: 0");
+            if (!(Platform.isAArch64() && Platform.isOSX())) { // see JDK-8262895
+                output.shouldContain("Narrow klass base: 0x0000000000000000");
+                if (!Platform.isAArch64() && !Platform.isOSX()) {
+                    output.shouldContain("Narrow klass shift: 0");
+                }
             }
         }
         output.shouldHaveExitValue(0);


### PR DESCRIPTION
Workaround for 8262895