### PR TITLE
Fixes most of issues in java/foreign/ tests, except va_args

### DIFF
--- a/src/hotspot/share/prims/perf.cpp
+++ b/src/hotspot/share/prims/perf.cpp
@@ -110,7 +110,6 @@ PERF_ENTRY(void, Perf_Detach(JNIEnv *env, jobject unused, jobject buffer))
 
   // get buffer address and capacity
   {
-   MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXExec, thread));
    ThreadToNativeFromVM ttnfv(thread);
    address = env->GetDirectBufferAddress(buffer);
    capacity = env->GetDirectBufferCapacity(buffer);

--- a/src/hotspot/share/prims/perf.cpp
+++ b/src/hotspot/share/prims/perf.cpp
@@ -110,6 +110,7 @@ PERF_ENTRY(void, Perf_Detach(JNIEnv *env, jobject unused, jobject buffer))
 
   // get buffer address and capacity
   {
+   MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXExec, thread));
    ThreadToNativeFromVM ttnfv(thread);
    address = env->GetDirectBufferAddress(buffer);
    capacity = env->GetDirectBufferCapacity(buffer);

--- a/src/hotspot/share/prims/universalNativeInvoker.cpp
+++ b/src/hotspot/share/prims/universalNativeInvoker.cpp
@@ -31,6 +31,7 @@ ProgrammableInvoker::Generator::Generator(CodeBuffer* code, const ABIDescriptor*
     _layout(layout) {}
 
 void ProgrammableInvoker::invoke_native(Stub stub, address buff, JavaThread* thread) {
+  MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXExec, thread));
   ThreadToNativeFromVM ttnfvm(thread);
   stub(buff);
 }

--- a/src/hotspot/share/prims/universalUpcallHandler.cpp
+++ b/src/hotspot/share/prims/universalUpcallHandler.cpp
@@ -36,6 +36,7 @@ extern struct JavaVM_ main_vm;
 
 void ProgrammableUpcallHandler::upcall_helper(JavaThread* thread, jobject rec, address buff) {
   JavaThread* THREAD = thread;
+  MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXWrite, thread));
   ThreadInVMfromNative tiv(THREAD);
   const UpcallMethod& upcall_method = instance().upcall_method;
 

--- a/src/hotspot/share/prims/universalUpcallHandler.cpp
+++ b/src/hotspot/share/prims/universalUpcallHandler.cpp
@@ -60,9 +60,11 @@ void ProgrammableUpcallHandler::attach_thread_and_do_upcall(jobject rec, address
     should_detach = true;
     thread = Thread::current();
   }
-  MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXWrite, thread));
 
-  upcall_helper(thread->as_Java_thread(), rec, buff);
+  {
+    MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXWrite, thread));
+    upcall_helper(thread->as_Java_thread(), rec, buff);
+  }
 
   if (should_detach) {
     JavaVM_ *vm = (JavaVM *)(&main_vm);

--- a/src/hotspot/share/prims/universalUpcallHandler.cpp
+++ b/src/hotspot/share/prims/universalUpcallHandler.cpp
@@ -36,7 +36,6 @@ extern struct JavaVM_ main_vm;
 
 void ProgrammableUpcallHandler::upcall_helper(JavaThread* thread, jobject rec, address buff) {
   JavaThread* THREAD = thread;
-  MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXWrite, thread));
   ThreadInVMfromNative tiv(THREAD);
   const UpcallMethod& upcall_method = instance().upcall_method;
 
@@ -61,6 +60,7 @@ void ProgrammableUpcallHandler::attach_thread_and_do_upcall(jobject rec, address
     should_detach = true;
     thread = Thread::current();
   }
+  MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXWrite, thread));
 
   upcall_helper(thread->as_Java_thread(), rec, buff);
 


### PR DESCRIPTION
This fixes most of issues in java/foreign/ tests, except va_args (JDK-8263512). 
This includes fix for JDK-8262896

Not sure it's done right looking from over all W^X arch.